### PR TITLE
Add a GitHub workflow to automatically backport changes

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,22 @@
+// .backportrc.json
+{
+  "repoOwner": "imphil",
+  "repoName": "cocotb-trials",
+
+  // Branches to backport to.
+  "targetBranchChoices": [
+    "stable/1.9"
+  ],
+
+  // Use `backport?:stable/VERSION` as indication of the target branch.
+  // Note: backslashes must be escaped.
+  "branchLabelMapping": {
+    "^backport?:(\\d\\.\\d)$": "stable/$1"
+  },
+
+  // Assign the label `backport-done` after a backport completed.
+  //"sourcePRLabels": ["backport-done"],
+
+  // Leave a note in the source PR if a backport failed.
+  "publishStatusCommentOnFailure": true
+}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,41 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# A workflow to automatically backport pull requests to a stable branch.
+#
+# This workflow uses the Backport CLI (https://github.com/sorenlouv/backport)
+# under the hood, which is configured in `.backportrc.json` in the repository
+# root.
+#
+# See https://github.com/sorenlouv/backport-github-action for documentation
+# on the used action.
+
+name: Backport PRs to stable branches
+
+on:
+  pull_request_target:
+    # Run this workflow when a label on a PR is added, or if it's closed.
+    types: ["labeled", "closed"]
+
+jobs:
+  backport-create:
+    name: Backport PR
+    if: github.event.pull_request.merged == true && !(startsWith(github.event.pull_request.labels.*.name, 'backport?:'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v9.5.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log
+
+  # TODO: Add a workflow that modifies the backport? to a backport+ label once
+  # the associated backport PR has been merged.


### PR DESCRIPTION
<!--

Thanks for improving cocotb! Here are some points to make this as smooth as possible.
Not all of them may be applicable.

Most important: please explain *why* you are proposing this change.

* Make sure you have read https://github.com/cocotb/cocotb/blob/master/CONTRIBUTING.md
* Extend or add a test under `tests/test_cases/`.
* Add documentation under `docs/source/`,
  docstrings in Python code, or Doxygen markup in C/C++ code.
  Use ``versionadded``/``versionchanged``/``deprecated``.
* Add a newsfragment - see `docs/source/newsfragments/README.rst`.
* Use `closes #XXXX` to auto-close the issue that this PR fixes (if such).

-->
